### PR TITLE
Discourage reusing matchers in the same example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1325,6 +1325,32 @@ it 'has a name' do
 end
 ----
 
+=== Matcher reuse
+
+Matchers are not supposed to be reused in the same example.
+Do not use memoized helpers to extract matchers, use non-memoized methods.
+
+[source,ruby]
+----
+# bad
+let(:be_odd_and_positive) { be_odd.and be_positive }
+
+it 'only contains odd and positive values' do
+  expect(set.first).to be_odd_and_positive
+  expect(set.last).to be_odd_and_positive
+end
+
+# good - no matcher instance reuse
+def be_odd_and_positive
+  be_odd.and be_positive
+end
+
+it 'only contains odd and positive values' do
+  expect(set.first).to be_odd_and_positive
+  expect(set.last).to be_odd_and_positive
+end
+----
+
 === Matcher Libraries
 
 Use third-party matcher libraries that provide convenience helpers that will significantly simplify the examples, https://github.com/thoughtbot/shoulda-matchers[Shoulda Matchers] are one worth mentioning.


### PR DESCRIPTION
Reusage may have undesired side effects, e.g. (see https://github.com/rspec/rspec-expectations/issues/1287):
```ruby
RSpec.describe 'A', :aggregate_failures do
  specify do
    matcher = contain_exactly(eq(1))

    expect([2]).to matcher
    expect([3]).to matcher
  end
end
```

will output for the second failure the same `extra` as for the first one:
```
the extra elements were:        [2]
```
instead of
```
the extra elements were:        [3]
```

https://github.com/rspec/rspec-expectations/blob/bd10f0cf3970932781efcd09b5e427877d16a6c2/lib/rspec/matchers/composable.rb#L113

    # Historically, a single matcher instance was only checked
    # against a single value. Given that the matcher was only
    # used once, it's been common to memoize some intermediate
    # calculation that is derived from the `actual` value in
    # order to reuse that intermediate result in the failure
    # message.
    #
    # This can cause a problem when using such a matcher as an
    # argument to another matcher in a composed matcher expression,
    # since the matcher instance may be checked against multiple
    # values and produce invalid results due to the memoization.
    #
    # To deal with this, we clone any matchers in `expected` via
    # this method when using `values_match?`, so that any memoization
    # does not "leak" between checks.

https://github.com/rspec/rspec-expectations/pull/518

The change is best viewed as https://github.com/rubocop-hq/rspec-style-guide/blob/discourage-using-memoized-matchers/README.adoc#matcher-reuse