### PR TITLE
Link to the GitHub project in "How to Contribute?"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1766,7 +1766,7 @@ You can also support the project (and RuboCop) with financial contributions via 
 
 It's easy, just follow the contribution guidelines below:
 
-* https://help.github.com/articles/fork-a-repo[Fork] the project on GitHub
+* https://help.github.com/articles/fork-a-repo[Fork] the https://github.com/rubocop/rspec-style-guide[project] on GitHub
 * Make your feature addition or bug fix in a feature branch
 * Include a http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[good description] of your changes
 * Push your feature branch to GitHub


### PR DESCRIPTION
https://rspec.rubystyle.guide/ suggests forking the project to contribute but didn't actually provide a link to the project itself. This fixes that.