### PR TITLE
Replace `response` with `body` in `include_json` example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1295,11 +1295,11 @@ end
 
 # good
 it 'returns JSON with temperature in Celsius' do
-  expect(response).to include_json(celsius: 30)
+  expect(body).to include_json(celsius: 30)
 end
 
 it 'returns JSON with temperature in Fahrenheit' do
-  expect(response).to include_json(fahrenheit: 86)
+  expect(body).to include_json(fahrenheit: 86)
 end
 ----
 


### PR DESCRIPTION
According to `rspec-json_expectations` gem, I think the actual value should be either a parsable string, or a hash or an array.

```ruby
RSpec::JsonExpectations::MatcherFactory.new(:include_json).define_matcher do
  def traverse(expected, actual, negate=false)
    unless expected.is_a?(Hash) ||
        expected.is_a?(Array) ||
        expected.is_a?(::RSpec::JsonExpectations::Matchers::UnorderedArrayMatcher)
      raise ArgumentError,
        "Expected value must be a json for include_json matcher"
    end

    representation = actual
    representation = JSON.parse(actual) if String === actual

    RSpec::JsonExpectations::JsonTraverser.traverse(
      @include_json_errors = { _negate: negate },
      expected,
      representation,
      negate
    )
  end
end
```