### PR TITLE
Refer to the method call under test with `subject`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1674,14 +1674,12 @@ describe SubscriberMailer do
   let(:subscriber) { double(Subscription, email: 'johndoe@test.com', name: 'John Doe') }
 
   describe 'successful registration email' do
-    subject { SubscriptionMailer.successful_registration_email(subscriber) }
+    subject(:email) { SubscriptionMailer.successful_registration_email(subscriber) }
 
-    its(:subject) { should == 'Successful Registration!' }
-    its(:from) { should == ['info@your_site.com'] }
-    its(:to) { should == [subscriber.email] }
+    it { is_expected.to have_attributes(subject: 'Successful Registration!', from: ['infor@your_site.com'], to: [subscriber.email]) }
 
     it 'contains the subscriber name' do
-      expect(subject.body.encoded).to match(subscriber.name)
+      expect(email.body.encoded).to match(subscriber.name)
     end
   end
 end

--- a/README.adoc
+++ b/README.adoc
@@ -335,12 +335,10 @@ end
 # good
 describe '#attributes' do
   let(:article) { FactoryBot.create(:article) }
-  subject { article.attributes }
+  subject(:attributes) { article.attributes }
 
-  specify do
-    expect(subject).to include(display_name: article.display_name)
-    expect(subject).to include article.created_at
-  end
+  it { is_expected.to include(display_name: article.display_name) }
+  it { is_expected.to include(created_at: article.created_at) }
 end
 
 describe '#attributes' do
@@ -911,17 +909,21 @@ Always use https://github.com/travisjeffery/timecop[Timecop] instead of stubbing
 
 [source,ruby]
 ----
-# bad
-it 'offsets the time 2 days into the future' do
-  current_time = Time.now
-  allow(Time).to receive(:now).and_return(current_time)
-  expect(subject).to eq(current_time + 2.days)
-end
+describe InvoiceReminder do
+  subject(:time_with_offset) { described_class.new.get_offset_time }
 
-# good
-it 'offsets the time 2 days into the future' do
-  Timecop.freeze(Time.now) do
-    expect(subject).to eq 2.days.from_now
+  # bad
+  it 'offsets the time 2 days into the future' do
+    current_time = Time.now
+    allow(Time).to receive(:now).and_return(current_time)
+    expect(time_with_offset).to eq(current_time + 2.days)
+  end
+
+  # good
+  it 'offsets the time 2 days into the future' do
+    Timecop.freeze(Time.now) do
+      expect(time_with_offset).to eq 2.days.from_now
+    end
   end
 end
 ----
@@ -1183,14 +1185,21 @@ Use RSpec's predicate matcher methods when possible.
 
 [source,ruby]
 ----
-# bad
-it 'is published' do
-  expect(subject.published?).to be true
-end
+describe Article do
+  subject(:article) { FactoryBot.create(:article) }
 
-# good
-it 'is published' do
-  expect(subject).to be_published
+  # bad
+  it 'is published' do
+    expect(article.published?).to be true
+  end
+
+  # good
+  it 'is published' do
+    expect(article).to be_published
+  end
+
+  # even better
+  it { is_expected.to be_published }
 end
 ----
 
@@ -1546,16 +1555,10 @@ Use `FactoryBot.create` to make real objects, or just use a new (unsaved) instan
 [source,ruby]
 ----
 describe Article do
-  let(:article) { FactoryBot.create(:article) }
+  subject(:article) { FactoryBot.build(:article) }
 
-  # Currently, 'subject' is the same as 'Article.new'
-  it 'is an instance of Article' do
-    expect(subject).to be_an Article
-  end
-
-  it 'is not persisted' do
-    expect(subject).to_not be_persisted
-  end
+  it { is_expected.to be_an Article }
+  it { is_expected.to_not be_persisted }
 end
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -323,7 +323,7 @@ end
 describe '#attributes' do
   context 'when display name is present' do
     before do
-      subject.display_name = 'something'
+      article.display_name = 'something'
     end
 
     it 'includes the display name' do
@@ -334,18 +334,19 @@ end
 
 # good
 describe '#attributes' do
-  subject { FactoryBot.create(:article) }
+  let(:article) { FactoryBot.create(:article) }
+  subject { article.attributes }
 
   specify do
-    expect(subject.attributes).to include subject.display_name
-    expect(subject.attributes).to include subject.created_at
+    expect(subject).to include article.display_name
+    expect(subject).to include article.created_at
   end
 end
 
 describe '#attributes' do
   context 'when display name is present' do
     before do
-      subject.display_name = 'something'
+      article.display_name = 'something'
     end
 
     it 'includes the display name' do
@@ -355,7 +356,7 @@ describe '#attributes' do
 
   context 'when display name is not present' do
     before do
-      subject.display_name = nil
+      article.display_name = nil
     end
 
     it 'does not include the display name' do
@@ -914,13 +915,13 @@ Always use https://github.com/travisjeffery/timecop[Timecop] instead of stubbing
 it 'offsets the time 2 days into the future' do
   current_time = Time.now
   allow(Time).to receive(:now).and_return(current_time)
-  expect(subject.get_offset_time).to eq(current_time + 2.days)
+  expect(subject).to eq(current_time + 2.days)
 end
 
 # good
 it 'offsets the time 2 days into the future' do
   Timecop.freeze(Time.now) do
-    expect(subject.get_offset_time).to eq 2.days.from_now
+    expect(subject).to eq 2.days.from_now
   end
 end
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -338,7 +338,7 @@ describe '#attributes' do
   subject { article.attributes }
 
   specify do
-    expect(subject).to include article.display_name
+    expect(subject).to include(display_name: article.display_name)
     expect(subject).to include article.created_at
   end
 end

--- a/README.adoc
+++ b/README.adoc
@@ -1546,10 +1546,10 @@ Use `FactoryBot.create` to make real objects, or just use a new (unsaved) instan
 [source,ruby]
 ----
 describe Article do
-  subject(:article) { FactoryBot.build(:article) }
+  subject(:article) { FactoryBot.create(:article) }
 
   it { is_expected.to be_an Article }
-  it { is_expected.to_not be_persisted }
+  it { is_expected.to be_persisted }
 end
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -337,19 +337,12 @@ describe '#attributes' do
   let(:article) { FactoryBot.create(:article) }
   subject(:attributes) { article.attributes }
 
-  it { is_expected.to include(display_name: article.display_name) }
-  it { is_expected.to include(created_at: article.created_at) }
-end
-
-describe '#attributes' do
   context 'when display name is present' do
     before do
       article.display_name = 'something'
     end
 
-    it 'includes the display name' do
-      # ...
-    end
+    it { is_expected.to include(display_name: article.display_name) }
   end
 
   context 'when display name is not present' do
@@ -357,9 +350,7 @@ describe '#attributes' do
       article.display_name = nil
     end
 
-    it 'does not include the display name' do
-      # ...
-    end
+    it { is_expected.not_to include(:display_name) }
   end
 end
 ----


### PR DESCRIPTION
As I've mentioned in [this blog post](https://simon.fish/blog/subject-to-change-effective-use-of-rspec.html), I think the examples should encourage making the `subject` always point to the object or method under test directly. There are some examples of cases in the docs that don't reflect this, which this PR changes.

Whether the examples use `expect(subject)` or `is_expected` is up for debate, but I tend to prefer `is_expected` only for one_liner examples like `it { is_expected.to have_attributes(name: 'Simon') }`.

It could be argued that these examples are only meant to highlight the difference between bad and good syntax and structure, and thus don't need to pay as much attention to the wider usage of the library where it isn't directly relevant to the lesson at hand. However, I feel like this more implicit encouragement of the correct use of `subject` will help folks to write better and more maintainable specs, especially if they're using this guide as a reference.