### PR TITLE
Added section on the declaration order of subject, let!/let and before/after hooks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -274,13 +274,13 @@ describe Article do
 end
 ----
 
-=== Declaring `subject`, `let!`/`let` and `before/`after` hooks
+=== Declaring `subject`, `let!`/`let` and `before`/`after` hooks
 
-When declaring `subject`, `let!`/`let` and `before/`after` hooks they should be in the following order:
+When declaring `subject`, `let!`/`let` and `before`/`after` hooks they should be in the following order:
 
 * `subject`
 * `let!`/`let`
-* `before/`after`
+* `before`/`after`
 
 [source,ruby]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -237,6 +237,8 @@ describe '#summary' do
 end
 ----
 
+== Example Group Structure
+
 === Leading `subject`
 
 When `subject` is used, it should be the first declaration in the example group.
@@ -272,7 +274,52 @@ describe Article do
 end
 ----
 
-== Example Group Structure
+=== Declaring `subject`, `let!`/`let` and `before/`after` hooks
+
+When declaring `subject`, `let!`/`let` and `before/`after` hooks they should be in the following order:
+
+* `subject`
+* `let!`/`let`
+* `before/`after`
+
+[source,ruby]
+----
+# bad
+describe Article do
+  before do
+    # ...
+  end
+
+  after do
+    # ...
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+  subject { FactoryBot.create(:some_article) }
+
+  describe '#summary' do
+    # ...
+  end
+end
+
+# good
+describe Article do
+  subject { FactoryBot.create(:some_article) }
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    # ...
+  end
+
+  after do
+    # ...
+  end
+
+  describe '#summary' do
+    # ...
+  end
+end
+----
 
 === Use Contexts
 


### PR DESCRIPTION
Added section on the declaration order of `subject`, `let!`/`let` and `before`/`after` hooks to the [Example Group Structure](https://github.com/rubocop/rspec-style-guide#example-group-structure) section.

<img width="893" alt="Screenshot 2023-10-05 at 07 50 10" src="https://github.com/rubocop/rspec-style-guide/assets/163900/2ff4160d-9220-42e2-b011-55ab936a0c6f">

Also, moved [Leading Subject] to the [Example Group Structure](https://github.com/rubocop/rspec-style-guide#example-group-structure) section, as mentioned [below](https://github.com/rubocop/rspec-style-guide/pull/135#pullrequestreview-1658274861).

<img width="898" alt="Screenshot 2023-10-05 at 07 46 28" src="https://github.com/rubocop/rspec-style-guide/assets/163900/8d6d5558-2dd8-42a6-a032-b9fe661fe695">

Resolves https://github.com/rubocop/rspec-style-guide/issues/134
