### PR TITLE
Fixes Context Cases example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -381,8 +381,8 @@ end
 
 # good
 describe '#attributes' do
-  let(:article) { FactoryBot.create(:article) }
   subject(:attributes) { article.attributes }
+  let(:article) { FactoryBot.create(:article) }
 
   context 'when display name is present' do
     before do


### PR DESCRIPTION
# [RE: Context Cases Documentation Issue](https://github.com/rubocop/rspec-style-guide/issues/136)

## Summary

A small detail was found in the Context Cases section of the documentation (see issue above for more details). The `# good` example was not in alignment with best practices.

### Changed

* Context Cases example section
